### PR TITLE
Custom onConnectionCallback function

### DIFF
--- a/lib/api/get-sqlite-router.js
+++ b/lib/api/get-sqlite-router.js
@@ -51,7 +51,7 @@ const mGetSqliteRouter = createMadonnaFunction({
   , fn: getSqliteRouter
 });
 
-function getSqliteRouter({ dbPath, config = {} }) {
+function getSqliteRouter({ dbPath, config = {}, onConnectionCallack = (db) => {} }) {
   return getSchema(dbPath)
     .then(schema => {
       dbSchema.set(schema);
@@ -63,8 +63,8 @@ function getSqliteRouter({ dbPath, config = {} }) {
         .use(koaDecodedQuerystring());
 
       return bPromise.props({
-        readOnly: bGetConnection(dbPath, sqlite3.OPEN_READONLY)
-        , readWrite: bGetConnection(dbPath, sqlite3.OPEN_READWRITE)
+        readOnly: bGetConnection(dbPath, sqlite3.OPEN_READONLY, onConnectionCallack)
+        , readWrite: bGetConnection(dbPath, sqlite3.OPEN_READWRITE, onConnectionCallack)
         , router: router
       });
     })
@@ -107,12 +107,15 @@ function getBuildRoutes(router, connections) {
   };
 }
 
-function bGetConnection(dbPath, mode) {
+function bGetConnection(dbPath, mode, onConnectionCallack) {
   return new bPromise((resolve, reject) => {
     const db = new sqlite3.Database(
       dbPath
       , mode
-      , err => (err) ? reject(err) : resolve(db)
+      , err => {
+        onConnectionCallack(db)
+        return (err) ? reject(err) : resolve(db)
+      }
     );
   });
 }

--- a/lib/api/get-sqlite-router.js
+++ b/lib/api/get-sqlite-router.js
@@ -46,12 +46,13 @@ const mGetSqliteRouter = createMadonnaFunction({
         , custom: { isSqlitePath: isSqliteFileSync }
       }
       , config: ['isLadenPlainObject']
+      , onConnectionCallback: ['isFunction']
     }
   }
   , fn: getSqliteRouter
 });
 
-function getSqliteRouter({ dbPath, config = {}, onConnectionCallack = (db) => {} }) {
+function getSqliteRouter({ dbPath, config = {}, onConnectionCallback = (db) => {} }) {
   return getSchema(dbPath)
     .then(schema => {
       dbSchema.set(schema);
@@ -63,8 +64,8 @@ function getSqliteRouter({ dbPath, config = {}, onConnectionCallack = (db) => {}
         .use(koaDecodedQuerystring());
 
       return bPromise.props({
-        readOnly: bGetConnection(dbPath, sqlite3.OPEN_READONLY, onConnectionCallack)
-        , readWrite: bGetConnection(dbPath, sqlite3.OPEN_READWRITE, onConnectionCallack)
+        readOnly: bGetConnection(dbPath, sqlite3.OPEN_READONLY, onConnectionCallback)
+        , readWrite: bGetConnection(dbPath, sqlite3.OPEN_READWRITE, onConnectionCallback)
         , router: router
       });
     })
@@ -107,13 +108,13 @@ function getBuildRoutes(router, connections) {
   };
 }
 
-function bGetConnection(dbPath, mode, onConnectionCallack) {
+function bGetConnection(dbPath, mode, onConnectionCallback) {
   return new bPromise((resolve, reject) => {
     const db = new sqlite3.Database(
       dbPath
       , mode
       , err => {
-        onConnectionCallack(db)
+        onConnectionCallback(db)
         return (err) ? reject(err) : resolve(db)
       }
     );


### PR DESCRIPTION
Gives the user of the library the option to provide a function that is triggered on connection to the sqlite database. This function receives the db object as an argument.

I added this was because in sqlite, the foreign key pragma is set to off by default. If you want to turn it on, you must do so for each new connection. These commits allow me to do as follows in skeleton.js:

```javascript
const onConnectionCallback = (db) => {
  db.run('PRAGMA foreign_keys=ON')
}

getSqliteRouter({ dbPath, onConnectionCallback })
  .then(router => {
    app.use(router.routes())
      .use(router.allowedMethods())
      .listen(PORT);

    console.log(`Listening on port: ${PORT}`);
  });
```